### PR TITLE
Use `message` key instead of `output` key in `results.json` files

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -53,7 +53,7 @@ else
     #      | GREP_COLOR='01;31' grep --color=always -E -e '^(ERROR:.*|.*failed)$|$' \
     #      | GREP_COLOR='01;32' grep --color=always -E -e '^.*passed$|$')
 
-    jq -n --arg output "${test_output}" '{version: 1, status: "fail", output: $output}' > ${results_file}
+    jq -n --arg output "${test_output}" '{version: 1, status: "fail", message: $output}' > ${results_file}
 fi
 
 echo "${slug}: done"

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "TODO: replace with correct output"
+  "message": "TODO: replace with correct output"
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "TODO: replace with correct output"
+  "message": "TODO: replace with correct output"
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "TODO: replace with correct output"
+  "message": "TODO: replace with correct output"
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "TODO: replace with correct output"
+  "message": "TODO: replace with correct output"
 }


### PR DESCRIPTION
This PR fixes an invalid implementation of the test runner v1 spec, where the `message` key was used instead of the `output` key in the `results.json` files

## Tracking

https://github.com/exercism/v3-launch/issues/38