### PR TITLE
docker ignore, updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 .git/
+.appends/
 .github/
-.bin/run-in-docker.sh
-.bin/run-tests-in-docker.sh
+.gitattributes
+.gitignore
+Dockerfile
+bin/run-in-docker.sh
+bin/run-tests-in-docker.sh
 tests/


### PR DESCRIPTION
The path for `bin/run-in-docker.sh` seemed not to work, updated

plus following docker ignores added,
- .appends/
- .gitattributes
- .gitignore
- Dockerfile