### PR TITLE
volume mount run tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@
 Dockerfile
 bin/run-in-docker.sh
 bin/run-tests-in-docker.sh
+bin/run-tests.sh
 tests/

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -22,6 +22,7 @@ docker run \
     --read-only \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
     --mount type=tmpfs,dst=/tmp \
+    --volume "${PWD}/bin/run-tests.sh:/opt/test-runner/bin/run-tests.sh" \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
     exercism/test-runner


### PR DESCRIPTION
This PR now mounts the `bin/run-tests.sh` file via a volume mount in `bin/run-tests-in-docker.sh`.
The benefit of doing it like this, is that the `bin/run-tests.sh` file now no longer needs to be included in the Docker image.
This in turn means that changes to `bin/run-tests.sh` don't require the Dockerfile to be rebuilt.