### PR TITLE
Allow run.sh to succeed for newly created testrunner repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
-# TODO: install packages required to run the tests
-# RUN apk add --no-cache jq coreutils
+# install packages required to run the tests
+RUN apk add --no-cache jq coreutils
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -33,8 +33,9 @@ echo "${slug}: testing..."
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
-# TODO: Replace 'RUN_TESTS_COMMAND' with the command to run the tests
-test_output=$(RUN_TESTS_COMMAND 2>&1)
+test_output=$(true)
+# TODO: substitute "true" with the actual command to run the test:
+# test_output=$(command_to_run_tests 2>&1)
 
 # Write the results.json file based on the exit code of the command that was 
 # just executed that tested the implementation file

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -33,8 +33,8 @@ echo "${slug}: testing..."
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
-test_output=$(true)
-# TODO: substitute "true" with the actual command to run the test:
+test_output=$(false)
+# TODO: substitute "false" with the actual command to run the test:
 # test_output=$(command_to_run_tests 2>&1)
 
 # Write the results.json file based on the exit code of the command that was 


### PR DESCRIPTION
This will allow "Sync org-wide files" PRs to pass unimpeded.

Fixes #80