### PR TITLE
Dockerfile: bump Alpine from 3.12 to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.17
 
 # install packages required to run the tests
 RUN apk add --no-cache jq coreutils


### PR DESCRIPTION
See the [list of releases][1].

[1]: https://alpinelinux.org/releases/

---

@ErikSchierboom Is there a reason that https://github.com/exercism/generic-test-runner/commit/d79ec6ba625cc52d7dae3f9fb0cdee6a66b89da9 bumped only to Alpine 3.12?